### PR TITLE
Tweaked Branch instructions

### DIFF
--- a/cpu/TR3200.md
+++ b/cpu/TR3200.md
@@ -5,7 +5,7 @@ cat : CPU
 ---
 TR3200 (Trillek Risc cpu 32 00) Specification
 ====================================
-Version 0.3.1 
+Version 0.4.0 
 
 
 SUMMARY
@@ -222,21 +222,21 @@ If M = 1 and L = 1 the next dword is used as 32 bit immediate value.
                              if M=1 & L=0       %pc = (Rd + (Imm << 2))         4
                              if M=0 | M=L=1     %pc = (Rd + Rn) & 0xFFFFFFFC    4
 
-    (Branch instructions)
-    IFEQ       0x60    Execute If Rd == Rn                                     +3 
-    IFNEQ      0x61    Execute If Rd != Rn                                     +3   
-    IFL        0x62    Execute If Rd < Rn (unsigned)                           +3
-    IFSL       0x63    Execute If Rd < Rn (signed)                             +3
-    IFLE       0x64    Execute If Rd <= Rn (unsigned)                          +3
-    IFSLE      0x65    Execute If Rd <= Rn (signed)                            +3
+    (Branch instructions 0x70 to 0x7F)
+    IFEQ       0x70    Execute If Rd == Rn                                     +3 
+    IFNEQ      0x71    Execute If Rd != Rn                                     +3   
+    IFL        0x72    Execute If Rd < Rn (unsigned)                           +3
+    IFSL       0x73    Execute If Rd < Rn (signed)                             +3
+    IFLE       0x74    Execute If Rd <= Rn (unsigned)                          +3
+    IFSLE      0x75    Execute If Rd <= Rn (signed)                            +3
 
-    IFG        0x66    Execute If Rd > Rn (unsigned)                           +3
-    IFSG       0x67    Execute If Rd > Rn (signed)                             +3
-    IFGE       0x68    Execute If Rd >= Rn (unsigned)                          +3
-    IFSGE      0x69    Execute If Rd >= Rn (signed)                            +3
+    IFG        0x76    Execute If Rd > Rn (unsigned)                           +3
+    IFSG       0x77    Execute If Rd > Rn (signed)                             +3
+    IFGE       0x78    Execute If Rd >= Rn (unsigned)                          +3
+    IFSGE      0x79    Execute If Rd >= Rn (signed)                            +3
 
-    IFBITS     0x6A    Execute If Rd & Rn != 0                                 +3
-    IFCLEAR    0x6B    Execute If Rd & Rn == 0                                 +3
+    IFBITS     0x7A    Execute If Rd & Rn != 0                                 +3
+    IFCLEAR    0x7B    Execute If Rd & Rn == 0                                 +3
 ```
 
 #### Notation and Examples

--- a/cpu/tr3200_sheet.html
+++ b/cpu/tr3200_sheet.html
@@ -82,16 +82,20 @@ cat : CPU
 	<tr><td>STORE</td><td>0&#120;48</td><td>Saves a dword</td><td>ram[Rn] = Rd</td><td>3</td></tr>
 	<tr><td>STOREW</td><td>0&#120;49</td><td>Saves a word</td><td>ram[Rn] = Rd</td><td>3</td></tr>
 	<tr><td>STOREB</td><td>0&#120;4A</td><td>Saves a byte</td><td>ram[Rn] = Rd</td><td>3</td></tr>
-	<tr><td>IFEQ</td><td>0&#120;4B</td><td>Execute If</td><td>Rd == Rn</td><td>3+</td></tr>
-	<tr><td>IFNEQ</td><td>0&#120;4C</td><td>Execute If</td><td>Rd != Rn</td><td>3+</td></tr>
-	<tr><td>IFL</td><td>0&#120;4D</td><td>Execute If</td><td>Rd &lt; Rn (unsigned)</td><td>3+</td></tr>
-	<tr><td>IFSL</td><td>0&#120;4E</td><td>Execute If</td><td>Rd &lt; Rn (signed)</td><td>3+</td></tr>
-	<tr><td>IFLE</td><td>0&#120;4F</td><td>Execute If</td><td>Rd &lt;= Rn (unsigned)</td><td>3+</td></tr>
-	<tr><td>IFSLE</td><td>0&#120;50</td><td>Execute If</td><td>Rd &lt;= Rn (signed)</td><td>3+</td></tr>
-	<tr><td>IFBITS</td><td>0&#120;51</td><td>Execute If</td><td>Rd &amp; Rn != 0</td><td>3+</td></tr>
-	<tr><td>IFCLEAR</td><td>0&#120;52</td><td>Execute If</td><td>Rd &amp; Rn == 0</td><td>3+</td></tr>
-	<tr><td>JMP</td><td>0&#120;53</td><td>Absolute Jump</td><td>%pc = (Rd + Rn) &amp; FFFFFC</td><td>3</td></tr>
-	<tr><td>CALL</td><td>0&#120;54</td><td>Absolute Call</td><td>PUSH %pc; JMP %rd, %rn</td><td>4</td></tr>
+	<tr><td>JMP</td><td>0&#120;4B</td><td>Absolute Jump</td><td>%pc = (Rd + Rn) &amp; FFFFFC</td><td>3</td></tr>
+	<tr><td>CALL</td><td>0&#120;4C</td><td>Absolute Call</td><td>PUSH %pc; JMP %rd, %rn</td><td>4</td></tr>
+	<tr><td>IFEQ</td><td>0&#120;70</td><td>Execute If</td><td>Rd == Rn</td><td>3+</td></tr>
+	<tr><td>IFNEQ</td><td>0&#120;71</td><td>Execute If</td><td>Rd != Rn</td><td>3+</td></tr>
+	<tr><td>IFL</td><td>0&#120;72</td><td>Execute If</td><td>Rd &lt; Rn (unsigned)</td><td>3+</td></tr>
+	<tr><td>IFSL</td><td>0&#120;73</td><td>Execute If</td><td>Rd &lt; Rn (signed)</td><td>3+</td></tr>
+	<tr><td>IFLE</td><td>0&#120;74</td><td>Execute If</td><td>Rd &lt;= Rn (unsigned)</td><td>3+</td></tr>
+	<tr><td>IFSLE</td><td>0&#120;75</td><td>Execute If</td><td>Rd &lt;= Rn (signed)</td><td>3+</td></tr>
+	<tr><td>IFG</td><td>0&#120;76</td><td>Execute If</td><td>Rd &gt; Rn (unsigned)</td><td>3+</td></tr>
+	<tr><td>IFSG</td><td>0&#120;77</td><td>Execute If</td><td>Rd &gt; Rn (signed)</td><td>3+</td></tr>
+	<tr><td>IFGE</td><td>0&#120;78</td><td>Execute If</td><td>Rd &gt;= Rn (unsigned)</td><td>3+</td></tr>
+	<tr><td>IFSGE</td><td>0&#120;79</td><td>Execute If</td><td>Rd &gt;= Rn (signed)</td><td>3+</td></tr>
+	<tr><td>IFBITS</td><td>0&#120;7A</td><td>Execute If</td><td>Rd &amp; Rn != 0</td><td>3+</td></tr>
+	<tr><td>IFCLEAR</td><td>0&#120;7B</td><td>Execute If</td><td>Rd &amp; Rn == 0</td><td>3+</td></tr>
 	</table>
 	</div>
 	<div id="column">
@@ -174,7 +178,7 @@ cat : CPU
 	
 	<div style="padding:10px;text-align:right;">
 		<span id="logo">TR3200</span></br>
-    Cheat Sheet <strong>v0.2.0</strong></br>
+    Cheat Sheet <strong>v0.3.0</strong></br>
 		http://trillek.org/
 	</div>
 	</div>


### PR DESCRIPTION
On request of issue #29, the branch instructions are moved to opcodes 0x70-0x7F.
On request of issue #32, is added IF Great branch instructions do ">" and ">=" comparators.

This PR would broke binary compatibility with previous versions, but keeps intact source code compatibility.

Closes #29 and #32 
